### PR TITLE
Add admin guard and worksheet management dashboard

### DIFF
--- a/app/Http/Controllers/Admin/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Admin/Auth/AuthenticatedSessionController.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\AdminLoginRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class AuthenticatedSessionController extends Controller
+{
+    public function create(): Response
+    {
+        return Inertia::render('Admin/Auth/Login', [
+            'status' => session('status'),
+        ]);
+    }
+
+    public function store(AdminLoginRequest $request): JsonResponse|RedirectResponse
+    {
+        $credentials = $request->only('email', 'password');
+        $remember = $request->boolean('remember');
+
+        if (! Auth::guard('admin')->attempt($credentials, $remember)) {
+            throw ValidationException::withMessages([
+                'email' => __('The provided credentials are incorrect.'),
+            ]);
+        }
+
+        $request->session()->regenerate();
+
+        return response()->api(__('Welcome back!'), meta: [
+            'redirectTo' => static fn (): RedirectResponse => Redirect::intended(route('admin.dashboard')),
+        ]);
+    }
+
+    public function destroy(Request $request): JsonResponse|RedirectResponse
+    {
+        Auth::guard('admin')->logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return response()->api(__('You have been logged out.'), meta: [
+            'redirectTo' => static fn (): RedirectResponse => Redirect::to(route('admin.login')),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Services\Admin\PageTypeService;
+use App\Services\Admin\WorksheetService;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class DashboardController extends Controller
+{
+    public function __construct(
+        private readonly PageTypeService $pageTypeService,
+        private readonly WorksheetService $worksheetService,
+    ) {
+    }
+
+    public function index(): Response
+    {
+        return Inertia::render('Admin/Dashboard', [
+            'metrics' => [
+                'page_types' => $this->pageTypeService->count(),
+                'worksheets' => $this->worksheetService->count(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Admin/PageTypeController.php
+++ b/app/Http/Controllers/Admin/PageTypeController.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\PageTypeStoreRequest;
+use App\Http\Requests\Admin\PageTypeUpdateRequest;
+use App\Http\Resources\Admin\PageTypeResource;
+use App\Models\PageType;
+use App\Services\Admin\PageTypeService;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Redirect;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class PageTypeController extends Controller
+{
+    public function __construct(
+        private readonly PageTypeService $pageTypeService,
+    ) {
+    }
+
+    public function index(): Response
+    {
+        $pageTypes = $this->pageTypeService->paginate();
+
+        return Inertia::render('Admin/PageTypes/Index', [
+            'pageTypes' => $this->formatPaginator($pageTypes),
+        ]);
+    }
+
+    public function create(): Response
+    {
+        return Inertia::render('Admin/PageTypes/Create');
+    }
+
+    public function store(PageTypeStoreRequest $request): JsonResponse|RedirectResponse
+    {
+        $pageType = $this->pageTypeService->store($request->validated());
+
+        return response()->api(__('Page type created successfully.'), meta: [
+            'redirectTo' => static fn (): RedirectResponse => Redirect::route('admin.page-types.edit', $pageType),
+        ]);
+    }
+
+    public function edit(PageType $pageType): Response
+    {
+        $pageType = $this->pageTypeService->find($pageType->getKey());
+
+        return Inertia::render('Admin/PageTypes/Edit', [
+            'pageType' => PageTypeResource::make($pageType)->resolve(),
+        ]);
+    }
+
+    public function update(PageTypeUpdateRequest $request, PageType $pageType): JsonResponse|RedirectResponse
+    {
+        $pageType = $this->pageTypeService->update(
+            $this->pageTypeService->find($pageType->getKey()),
+            $request->validated(),
+        );
+
+        return response()->api(__('Page type updated successfully.'), meta: [
+            'redirectTo' => static fn (): RedirectResponse => Redirect::route('admin.page-types.edit', $pageType),
+        ]);
+    }
+
+    public function destroy(PageType $pageType): JsonResponse|RedirectResponse
+    {
+        $this->pageTypeService->delete(
+            $this->pageTypeService->find($pageType->getKey())
+        );
+
+        return response()->api(__('Page type deleted successfully.'), meta: [
+            'redirectTo' => static fn (): RedirectResponse => Redirect::route('admin.page-types.index'),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function formatPaginator(LengthAwarePaginator $paginator): array
+    {
+        return [
+            'data' => PageTypeResource::collection($paginator->items())->resolve(),
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'from' => $paginator->firstItem(),
+                'last_page' => $paginator->lastPage(),
+                'per_page' => $paginator->perPage(),
+                'to' => $paginator->lastItem(),
+                'total' => $paginator->total(),
+            ],
+            'links' => [
+                'first' => $paginator->url(1),
+                'last' => $paginator->url($paginator->lastPage()),
+                'prev' => $paginator->previousPageUrl(),
+                'next' => $paginator->nextPageUrl(),
+            ],
+        ];
+    }
+}

--- a/app/Http/Controllers/Admin/WorksheetController.php
+++ b/app/Http/Controllers/Admin/WorksheetController.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\WorksheetStoreRequest;
+use App\Http\Requests\Admin\WorksheetUpdateRequest;
+use App\Http\Resources\Admin\PageTypeResource;
+use App\Http\Resources\Admin\WorksheetResource;
+use App\Models\Worksheet;
+use App\Services\Admin\PageTypeService;
+use App\Services\Admin\WorksheetService;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Redirect;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class WorksheetController extends Controller
+{
+    public function __construct(
+        private readonly WorksheetService $worksheetService,
+        private readonly PageTypeService $pageTypeService,
+    ) {
+    }
+
+    public function index(): Response
+    {
+        $worksheets = $this->worksheetService->paginate();
+
+        return Inertia::render('Admin/Worksheets/Index', [
+            'worksheets' => $this->formatPaginator($worksheets),
+        ]);
+    }
+
+    public function create(): Response
+    {
+        return Inertia::render('Admin/Worksheets/Create', [
+            'pageTypes' => PageTypeResource::collection($this->pageTypeService->all())->resolve(),
+        ]);
+    }
+
+    public function store(WorksheetStoreRequest $request): JsonResponse|RedirectResponse
+    {
+        $worksheet = $this->worksheetService->store($request->validated());
+
+        return response()->api(__('Worksheet created successfully.'), meta: [
+            'redirectTo' => static fn (): RedirectResponse => Redirect::route('admin.worksheets.show', $worksheet),
+        ]);
+    }
+
+    public function show(Worksheet $worksheet): Response
+    {
+        $worksheet = $this->worksheetService->find($worksheet->getKey());
+
+        return Inertia::render('Admin/Worksheets/Show', [
+            'worksheet' => WorksheetResource::make($worksheet)->resolve(),
+        ]);
+    }
+
+    public function edit(Worksheet $worksheet): Response
+    {
+        $worksheet = $this->worksheetService->find($worksheet->getKey());
+
+        return Inertia::render('Admin/Worksheets/Edit', [
+            'worksheet' => WorksheetResource::make($worksheet)->resolve(),
+        ]);
+    }
+
+    public function update(WorksheetUpdateRequest $request, Worksheet $worksheet): JsonResponse|RedirectResponse
+    {
+        $worksheet = $this->worksheetService->update(
+            $this->worksheetService->find($worksheet->getKey()),
+            $request->validated(),
+        );
+
+        return response()->api(__('Worksheet updated successfully.'), meta: [
+            'redirectTo' => static fn (): RedirectResponse => Redirect::route('admin.worksheets.edit', $worksheet),
+        ]);
+    }
+
+    public function destroy(Worksheet $worksheet): JsonResponse|RedirectResponse
+    {
+        $this->worksheetService->delete(
+            $this->worksheetService->find($worksheet->getKey())
+        );
+
+        return response()->api(__('Worksheet deleted successfully.'), meta: [
+            'redirectTo' => static fn (): RedirectResponse => Redirect::route('admin.worksheets.index'),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function formatPaginator(LengthAwarePaginator $paginator): array
+    {
+        return [
+            'data' => WorksheetResource::collection($paginator->items())->resolve(),
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'from' => $paginator->firstItem(),
+                'last_page' => $paginator->lastPage(),
+                'per_page' => $paginator->perPage(),
+                'to' => $paginator->lastItem(),
+                'total' => $paginator->total(),
+            ],
+            'links' => [
+                'first' => $paginator->url(1),
+                'last' => $paginator->url($paginator->lastPage()),
+                'prev' => $paginator->previousPageUrl(),
+                'next' => $paginator->nextPageUrl(),
+            ],
+        ];
+    }
+}

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Illuminate\Auth\Middleware\Authenticate as Middleware;
+use Illuminate\Http\Request;
+
+class Authenticate extends Middleware
+{
+    protected function redirectTo(Request $request): ?string
+    {
+        if ($request->expectsJson()) {
+            return null;
+        }
+
+        if ($request->routeIs('admin.*')) {
+            return route('admin.login');
+        }
+
+        return route('login');
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Http\Resources\Admin\AdminResource;
 use App\Http\Resources\UserResource;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Inertia\Middleware;
 use Tighten\Ziggy\Ziggy;
 
@@ -38,6 +40,9 @@ class HandleInertiaRequests extends Middleware
             'auth' => [
                 'user' => $request->user()
                     ? UserResource::make($request->user())->resolve()
+                    : null,
+                'admin' => Auth::guard('admin')->user()
+                    ? AdminResource::make(Auth::guard('admin')->user())->resolve()
                     : null,
             ],
             'ziggy' => fn () => [

--- a/app/Http/Requests/Admin/AdminLoginRequest.php
+++ b/app/Http/Requests/Admin/AdminLoginRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AdminLoginRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email'],
+            'password' => ['required', 'string'],
+            'remember' => ['nullable', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/PageTypeStoreRequest.php
+++ b/app/Http/Requests/Admin/PageTypeStoreRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class PageTypeStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string|Rule>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'columns' => ['required', 'integer', 'min:1', 'max:10'],
+            'rows' => ['required', 'integer', 'min:1', 'max:10'],
+            'logo' => ['nullable', 'image', 'max:5120'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $columns = (int) $this->input('columns', 0);
+            $rows = (int) $this->input('rows', 0);
+
+            if ($columns * $rows === 0) {
+                return;
+            }
+
+            if ($columns * $rows > 12) {
+                $validator->errors()->add(
+                    'columns',
+                    __('The selected layout must contain 12 sections or fewer.'),
+                );
+            }
+        });
+    }
+}

--- a/app/Http/Requests/Admin/PageTypeUpdateRequest.php
+++ b/app/Http/Requests/Admin/PageTypeUpdateRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class PageTypeUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string|Rule>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'columns' => ['sometimes', 'required', 'integer', 'min:1', 'max:10'],
+            'rows' => ['sometimes', 'required', 'integer', 'min:1', 'max:10'],
+            'logo' => ['nullable', 'image', 'max:5120'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $columns = (int) ($this->input('columns') ?? $this->route('page_type')?->columns ?? 0);
+            $rows = (int) ($this->input('rows') ?? $this->route('page_type')?->rows ?? 0);
+
+            if ($columns * $rows === 0) {
+                return;
+            }
+
+            if ($columns * $rows > 12) {
+                $validator->errors()->add(
+                    'columns',
+                    __('The selected layout must contain 12 sections or fewer.'),
+                );
+            }
+        });
+    }
+}

--- a/app/Http/Requests/Admin/WorksheetStoreRequest.php
+++ b/app/Http/Requests/Admin/WorksheetStoreRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use App\Models\PageType;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class WorksheetStoreRequest extends FormRequest
+{
+    private ?PageType $pageType = null;
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string|Rule>>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'notes' => ['nullable', 'string'],
+            'page_type_id' => ['required', Rule::exists('page_types', 'id')],
+            'images' => ['required', 'array'],
+            'images.*' => ['required', 'image', 'max:5120'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $pageType = $this->resolvePageType();
+
+            if (! $pageType) {
+                return;
+            }
+
+            $expected = $pageType->sections_count;
+            $provided = count($this->file('images', []));
+
+            if ($expected !== $provided) {
+                $message = $expected === 1
+                    ? __('Please upload exactly 1 image for this layout.')
+                    : __('Please upload exactly :count images for this layout.', ['count' => $expected]);
+
+                $validator->errors()->add('images', $message);
+            }
+        });
+    }
+
+    private function resolvePageType(): ?PageType
+    {
+        if ($this->pageType instanceof PageType) {
+            return $this->pageType;
+        }
+
+        $pageTypeId = $this->input('page_type_id');
+        if (! $pageTypeId) {
+            return null;
+        }
+
+        return $this->pageType = PageType::query()->find($pageTypeId);
+    }
+}

--- a/app/Http/Requests/Admin/WorksheetUpdateRequest.php
+++ b/app/Http/Requests/Admin/WorksheetUpdateRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use App\Models\Worksheet;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+
+class WorksheetUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string|Rule>>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['sometimes', 'required', 'string', 'max:255'],
+            'notes' => ['nullable', 'string'],
+            'images' => ['nullable', 'array'],
+            'images.*' => ['required_with:images', 'image', 'max:5120'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            if (! $this->hasFile('images')) {
+                return;
+            }
+
+            /** @var Worksheet $worksheet */
+            $worksheet = $this->route('worksheet');
+            $expected = $worksheet?->pageType?->sections_count;
+            $provided = count($this->file('images', []));
+
+            if ($expected && $expected !== $provided) {
+                $message = $expected === 1
+                    ? __('Please upload exactly 1 image for this layout.')
+                    : __('Please upload exactly :count images for this layout.', ['count' => $expected]);
+
+                $validator->errors()->add('images', $message);
+            }
+        });
+    }
+}

--- a/app/Http/Resources/Admin/AdminResource.php
+++ b/app/Http/Resources/Admin/AdminResource.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Admin;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Admin */
+class AdminResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource->getKey(),
+            'name' => $this->resource->name,
+            'email' => $this->resource->email,
+            'created_at' => $this->resource->created_at,
+            'updated_at' => $this->resource->updated_at,
+        ];
+    }
+}

--- a/app/Http/Resources/Admin/PageTypeResource.php
+++ b/app/Http/Resources/Admin/PageTypeResource.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Admin;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Storage;
+
+/** @mixin \App\Models\PageType */
+class PageTypeResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource->getKey(),
+            'name' => $this->resource->name,
+            'columns' => $this->resource->columns,
+            'rows' => $this->resource->rows,
+            'sections' => $this->resource->sections_count,
+            'logo_path' => $this->resource->logo_path,
+            'logo_url' => $this->resource->logo_path
+                ? Storage::disk('public')->url($this->resource->logo_path)
+                : null,
+            'created_at' => $this->resource->created_at,
+            'updated_at' => $this->resource->updated_at,
+        ];
+    }
+}

--- a/app/Http/Resources/Admin/WorksheetImageResource.php
+++ b/app/Http/Resources/Admin/WorksheetImageResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Admin;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Storage;
+
+/** @mixin \App\Models\WorksheetImage */
+class WorksheetImageResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource->getKey(),
+            'section_index' => $this->resource->section_index,
+            'image_path' => $this->resource->image_path,
+            'image_url' => Storage::disk('public')->url($this->resource->image_path),
+            'created_at' => $this->resource->created_at,
+            'updated_at' => $this->resource->updated_at,
+        ];
+    }
+}

--- a/app/Http/Resources/Admin/WorksheetResource.php
+++ b/app/Http/Resources/Admin/WorksheetResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Admin;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Worksheet */
+class WorksheetResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource->getKey(),
+            'title' => $this->resource->title,
+            'notes' => $this->resource->notes,
+            'page_type_id' => $this->resource->page_type_id,
+            'created_at' => $this->resource->created_at,
+            'updated_at' => $this->resource->updated_at,
+            'page_type' => PageTypeResource::make($this->whenLoaded('pageType')),
+            'images' => WorksheetImageResource::collection($this->whenLoaded('images')),
+        ];
+    }
+}

--- a/app/Models/Admin.php
+++ b/app/Models/Admin.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class Admin extends Authenticatable
+{
+    /** @use HasFactory<\Database\Factories\AdminFactory> */
+    use HasFactory, Notifiable;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'password' => 'hashed',
+        ];
+    }
+}

--- a/app/Models/PageType.php
+++ b/app/Models/PageType.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class PageType extends Model
+{
+    /** @use HasFactory<\Database\Factories\PageTypeFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'columns',
+        'rows',
+        'logo_path',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'columns' => 'integer',
+            'rows' => 'integer',
+        ];
+    }
+
+    public function worksheets(): HasMany
+    {
+        return $this->hasMany(Worksheet::class);
+    }
+
+    public function getSectionsCountAttribute(): int
+    {
+        return $this->columns * $this->rows;
+    }
+}

--- a/app/Models/Worksheet.php
+++ b/app/Models/Worksheet.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Worksheet extends Model
+{
+    /** @use HasFactory<\Database\Factories\WorksheetFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'title',
+        'notes',
+        'page_type_id',
+    ];
+
+    public function pageType(): BelongsTo
+    {
+        return $this->belongsTo(PageType::class);
+    }
+
+    public function images(): HasMany
+    {
+        return $this->hasMany(WorksheetImage::class)->orderBy('section_index');
+    }
+}

--- a/app/Models/WorksheetImage.php
+++ b/app/Models/WorksheetImage.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WorksheetImage extends Model
+{
+    /** @use HasFactory<\Database\Factories\WorksheetImageFactory> */
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'worksheet_id',
+        'section_index',
+        'image_path',
+    ];
+
+    public function worksheet(): BelongsTo
+    {
+        return $this->belongsTo(Worksheet::class);
+    }
+}

--- a/app/Services/Admin/PageTypeService.php
+++ b/app/Services/Admin/PageTypeService.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Admin;
+
+use App\Models\PageType;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+class PageTypeService
+{
+    public function __construct(
+        private readonly WorksheetService $worksheetService,
+    ) {
+    }
+
+    public function paginate(int $perPage = 10): LengthAwarePaginator
+    {
+        return PageType::query()
+            ->latest()
+            ->paginate($perPage);
+    }
+
+    public function count(): int
+    {
+        return PageType::query()->count();
+    }
+
+    public function find(int $id): PageType
+    {
+        return PageType::query()->findOrFail($id);
+    }
+
+    /**
+     * @return Collection<int, PageType>
+     */
+    public function all(): Collection
+    {
+        return PageType::query()
+            ->orderBy('name')
+            ->get();
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function store(array $attributes): PageType
+    {
+        $logo = $attributes['logo'] ?? null;
+        unset($attributes['logo']);
+
+        return DB::transaction(function () use ($attributes, $logo): PageType {
+            if ($logo instanceof UploadedFile) {
+                $attributes['logo_path'] = $this->storeLogo($logo);
+            }
+
+            /** @var PageType $pageType */
+            $pageType = PageType::query()->create($attributes);
+
+            return $pageType;
+        });
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function update(PageType $pageType, array $attributes): PageType
+    {
+        $logo = $attributes['logo'] ?? null;
+        unset($attributes['logo']);
+
+        return DB::transaction(function () use ($pageType, $attributes, $logo): PageType {
+            if ($logo instanceof UploadedFile) {
+                $this->deleteLogo($pageType->logo_path);
+                $attributes['logo_path'] = $this->storeLogo($logo);
+            }
+
+            $pageType->fill($attributes);
+            $pageType->save();
+
+            return $pageType->refresh();
+        });
+    }
+
+    public function delete(PageType $pageType): void
+    {
+        DB::transaction(function () use ($pageType): void {
+            $pageType->loadMissing('worksheets.images');
+
+            foreach ($pageType->worksheets as $worksheet) {
+                $this->worksheetService->delete($worksheet);
+            }
+
+            $this->deleteLogo($pageType->logo_path);
+
+            $pageType->delete();
+        });
+    }
+
+    private function storeLogo(UploadedFile $logo): string
+    {
+        return $logo->store('logos', 'public');
+    }
+
+    private function deleteLogo(?string $path): void
+    {
+        if (! $path) {
+            return;
+        }
+
+        Storage::disk('public')->delete($path);
+    }
+}

--- a/app/Services/Admin/WorksheetService.php
+++ b/app/Services/Admin/WorksheetService.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Admin;
+
+use App\Models\Worksheet;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+class WorksheetService
+{
+    public function paginate(int $perPage = 10): LengthAwarePaginator
+    {
+        return Worksheet::query()
+            ->with('pageType')
+            ->latest()
+            ->paginate($perPage);
+    }
+
+    public function count(): int
+    {
+        return Worksheet::query()->count();
+    }
+
+    public function find(int $id): Worksheet
+    {
+        return Worksheet::query()
+            ->with(['pageType', 'images'])
+            ->findOrFail($id);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function store(array $attributes): Worksheet
+    {
+        /** @var array<int, UploadedFile> $images */
+        $images = $attributes['images'] ?? [];
+        unset($attributes['images']);
+
+        return DB::transaction(function () use ($attributes, $images): Worksheet {
+            /** @var Worksheet $worksheet */
+            $worksheet = Worksheet::query()->create($attributes);
+
+            $this->syncImages($worksheet, $images);
+
+            return $worksheet->load(['pageType', 'images']);
+        });
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function update(Worksheet $worksheet, array $attributes): Worksheet
+    {
+        /** @var array<int, UploadedFile>|null $images */
+        $images = $attributes['images'] ?? null;
+        unset($attributes['images']);
+
+        return DB::transaction(function () use ($worksheet, $attributes, $images): Worksheet {
+            $worksheet->fill($attributes);
+            $worksheet->save();
+
+            if ($images !== null) {
+                $this->syncImages($worksheet, $images, true);
+            }
+
+            return $worksheet->load(['pageType', 'images']);
+        });
+    }
+
+    public function delete(Worksheet $worksheet): void
+    {
+        DB::transaction(function () use ($worksheet): void {
+            $worksheet->loadMissing('images');
+
+            foreach ($worksheet->images as $image) {
+                Storage::disk('public')->delete($image->image_path);
+            }
+
+            $worksheet->delete();
+        });
+    }
+
+    /**
+     * @param  array<int, UploadedFile>  $images
+     */
+    private function syncImages(Worksheet $worksheet, array $images, bool $replace = false): void
+    {
+        if ($replace) {
+            $worksheet->loadMissing('images');
+
+            foreach ($worksheet->images as $image) {
+                Storage::disk('public')->delete($image->image_path);
+            }
+
+            $worksheet->images()->delete();
+        }
+
+        foreach (array_values($images) as $index => $image) {
+            $worksheet->images()->create([
+                'section_index' => $index,
+                'image_path' => $image->store('worksheet-images', 'public'),
+            ]);
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,12 +1,22 @@
 <?php
 
+use App\Http\Middleware\Authenticate;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Support\Facades\Route;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__.'/../routes/web.php',
+        using: function (): void {
+            Route::middleware('web')
+                ->group(base_path('routes/web.php'));
+
+            Route::middleware('web')
+                ->prefix('admin')
+                ->as('admin.')
+                ->group(base_path('routes/admin.php'));
+        },
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
@@ -16,7 +26,9 @@ return Application::configure(basePath: dirname(__DIR__))
             \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,
         ]);
 
-        //
+        $middleware->alias([
+            'auth' => Authenticate::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/config/auth.php
+++ b/config/auth.php
@@ -40,6 +40,11 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+
+        'admin' => [
+            'driver' => 'session',
+            'provider' => 'admins',
+        ],
     ],
 
     /*
@@ -63,6 +68,11 @@ return [
         'users' => [
             'driver' => 'eloquent',
             'model' => env('AUTH_MODEL', App\Models\User::class),
+        ],
+
+        'admins' => [
+            'driver' => 'eloquent',
+            'model' => App\Models\Admin::class,
         ],
 
         // 'users' => [
@@ -93,6 +103,13 @@ return [
     'passwords' => [
         'users' => [
             'provider' => 'users',
+            'table' => env('AUTH_PASSWORD_RESET_TOKEN_TABLE', 'password_reset_tokens'),
+            'expire' => 60,
+            'throttle' => 60,
+        ],
+
+        'admins' => [
+            'provider' => 'admins',
             'table' => env('AUTH_PASSWORD_RESET_TOKEN_TABLE', 'password_reset_tokens'),
             'expire' => 60,
             'throttle' => 60,

--- a/database/migrations/2024_01_01_000003_create_admins_table.php
+++ b/database/migrations/2024_01_01_000003_create_admins_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends \Illuminate\Database\Migrations\Migration
+{
+    public function up(): void
+    {
+        Schema::create('admins', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('admins');
+    }
+};

--- a/database/migrations/2024_01_01_000004_create_page_types_table.php
+++ b/database/migrations/2024_01_01_000004_create_page_types_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends \Illuminate\Database\Migrations\Migration
+{
+    public function up(): void
+    {
+        Schema::create('page_types', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name');
+            $table->unsignedTinyInteger('columns');
+            $table->unsignedTinyInteger('rows');
+            $table->string('logo_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('page_types');
+    }
+};

--- a/database/migrations/2024_01_01_000005_create_worksheets_table.php
+++ b/database/migrations/2024_01_01_000005_create_worksheets_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends \Illuminate\Database\Migrations\Migration
+{
+    public function up(): void
+    {
+        Schema::create('worksheets', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('page_type_id')->constrained('page_types')->cascadeOnDelete();
+            $table->string('title');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('worksheets');
+    }
+};

--- a/database/migrations/2024_01_01_000006_create_worksheet_images_table.php
+++ b/database/migrations/2024_01_01_000006_create_worksheet_images_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends \Illuminate\Database\Migrations\Migration
+{
+    public function up(): void
+    {
+        Schema::create('worksheet_images', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('worksheet_id')->constrained('worksheets')->cascadeOnDelete();
+            $table->unsignedInteger('section_index');
+            $table->string('image_path');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('worksheet_images');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Admin;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
@@ -19,5 +20,13 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        Admin::query()->firstOrCreate(
+            ['email' => 'admin@example.com'],
+            [
+                'name' => 'Administrator',
+                'password' => 'password',
+            ],
+        );
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,54 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.a4-sheet {
+    width: 210mm;
+    min-height: 297mm;
+    background-color: #ffffff;
+    padding: 18mm;
+    box-shadow: 0 25px 50px -12px rgba(30, 64, 175, 0.25);
+    border-radius: 0.5rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.a4-grid {
+    display: grid;
+    gap: 6mm;
+    flex: 1;
+}
+
+.a4-grid__cell {
+    border: 1px dashed rgba(99, 102, 241, 0.5);
+    border-radius: 0.375rem;
+    padding: 4mm;
+    background-color: rgba(239, 246, 255, 0.65);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+@media print {
+    body {
+        background: #ffffff;
+    }
+
+    .a4-sheet {
+        width: 100%;
+        min-height: auto;
+        box-shadow: none;
+        margin: 0;
+        padding: 12mm;
+        border-radius: 0;
+    }
+
+    .a4-grid {
+        gap: 4mm;
+    }
+
+    .a4-grid__cell {
+        border: 1px solid rgba(148, 163, 184, 0.6);
+        background-color: transparent;
+    }
+}

--- a/resources/js/Components/Admin/PageTypeForm.jsx
+++ b/resources/js/Components/Admin/PageTypeForm.jsx
@@ -1,0 +1,105 @@
+import InputError from '@/Components/InputError';
+import InputLabel from '@/Components/InputLabel';
+import PrimaryButton from '@/Components/PrimaryButton';
+import TextInput from '@/Components/TextInput';
+
+export default function PageTypeForm({
+    data,
+    setData,
+    errors,
+    processing,
+    onSubmit,
+    pageType,
+    submitLabel = 'Save',
+}) {
+    return (
+        <form onSubmit={onSubmit} className="space-y-6">
+            <div>
+                <InputLabel htmlFor="name" value="Page Type Name" />
+                <TextInput
+                    id="name"
+                    value={data.name}
+                    className="mt-1 block w-full"
+                    onChange={(event) => setData('name', event.target.value)}
+                    required
+                />
+                <InputError message={errors.name} className="mt-2" />
+            </div>
+
+            <div className="grid gap-6 sm:grid-cols-2">
+                <div>
+                    <InputLabel htmlFor="columns" value="Columns" />
+                    <TextInput
+                        id="columns"
+                        type="number"
+                        min="1"
+                        max="10"
+                        value={data.columns}
+                        className="mt-1 block w-full"
+                        onChange={(event) => setData('columns', event.target.value)}
+                        required
+                    />
+                    <InputError message={errors.columns} className="mt-2" />
+                </div>
+
+                <div>
+                    <InputLabel htmlFor="rows" value="Rows" />
+                    <TextInput
+                        id="rows"
+                        type="number"
+                        min="1"
+                        max="10"
+                        value={data.rows}
+                        className="mt-1 block w-full"
+                        onChange={(event) => setData('rows', event.target.value)}
+                        required
+                    />
+                    <InputError message={errors.rows} className="mt-2" />
+                </div>
+            </div>
+
+            <div>
+                <InputLabel htmlFor="logo" value="Logo" />
+                <input
+                    id="logo"
+                    type="file"
+                    accept="image/*"
+                    className="mt-1 block w-full text-sm text-slate-600"
+                    onChange={(event) => setData('logo', event.target.files[0])}
+                />
+                <InputError message={errors.logo} className="mt-2" />
+                {pageType?.logo_url && (
+                    <div className="mt-3 flex items-center gap-3">
+                        <img
+                            src={pageType.logo_url}
+                            alt={`${pageType.name} logo`}
+                            className="h-16 w-16 rounded border border-slate-200 object-contain"
+                        />
+                        <p className="text-sm text-slate-500">
+                            Uploading a new file will replace the existing logo.
+                        </p>
+                    </div>
+                )}
+            </div>
+
+            <div className="rounded-md bg-slate-50 p-4 text-sm text-slate-600">
+                <p>
+                    Columns × rows determine how many activity slots this layout
+                    provides. The total number of sections must be 12 or fewer
+                    so the worksheet remains printable on A4 paper.
+                </p>
+                <p className="mt-2 font-medium text-slate-700">
+                    Current configuration:{' '}
+                    <span className="font-semibold text-indigo-600">
+                        {Number(data.columns || 0) * Number(data.rows || 0)}
+                    </span>{' '}
+                    sections.
+                </p>
+            </div>
+
+            <div className="flex justify-end">
+                <PrimaryButton disabled={processing}>{submitLabel}</PrimaryButton>
+            </div>
+        </form>
+    );
+}

--- a/resources/js/Components/Admin/WorksheetForm.jsx
+++ b/resources/js/Components/Admin/WorksheetForm.jsx
@@ -1,0 +1,176 @@
+import InputError from '@/Components/InputError';
+import InputLabel from '@/Components/InputLabel';
+import PrimaryButton from '@/Components/PrimaryButton';
+import TextInput from '@/Components/TextInput';
+import { useMemo } from 'react';
+
+export default function WorksheetForm({
+    data,
+    setData,
+    errors,
+    processing,
+    onSubmit,
+    pageTypes = [],
+    worksheet = null,
+    submitLabel = 'Save',
+    mode = 'create',
+}) {
+    const selectedPageType = useMemo(() => {
+        const fromSelect = pageTypes.find(
+            (type) => String(type.id) === String(data.page_type_id),
+        );
+
+        if (fromSelect) {
+            return fromSelect;
+        }
+
+        return worksheet?.page_type ?? null;
+    }, [data.page_type_id, pageTypes, worksheet]);
+
+    const expectedImages = selectedPageType?.sections ?? 0;
+
+    return (
+        <form onSubmit={onSubmit} className="space-y-6">
+            <div className="grid gap-6 lg:grid-cols-2">
+                <div className="space-y-4">
+                    <div>
+                        <InputLabel htmlFor="title" value="Worksheet title" />
+                        <TextInput
+                            id="title"
+                            value={data.title}
+                            className="mt-1 block w-full"
+                            onChange={(event) => setData('title', event.target.value)}
+                            required
+                        />
+                        <InputError message={errors.title} className="mt-2" />
+                    </div>
+
+                    <div>
+                        <InputLabel htmlFor="notes" value="Notes (optional)" />
+                        <textarea
+                            id="notes"
+                            value={data.notes ?? ''}
+                            className="mt-1 block w-full rounded-md border border-slate-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                            rows={4}
+                            onChange={(event) => setData('notes', event.target.value)}
+                        />
+                        <InputError message={errors.notes} className="mt-2" />
+                    </div>
+
+                    <div>
+                        <InputLabel htmlFor="page_type_id" value="Layout" />
+                        {mode === 'create' ? (
+                            <select
+                                id="page_type_id"
+                                className="mt-1 block w-full rounded-md border border-slate-300 bg-white py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                                value={data.page_type_id || ''}
+                                onChange={(event) => setData('page_type_id', event.target.value)}
+                                required
+                            >
+                                <option value="" disabled>
+                                    Select a layout
+                                </option>
+                                {pageTypes.map((type) => (
+                                    <option key={type.id} value={type.id}>
+                                        {type.name} ({type.columns} × {type.rows})
+                                    </option>
+                                ))}
+                            </select>
+                        ) : (
+                            <div className="mt-1 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600">
+                                {selectedPageType?.name} ({selectedPageType?.columns} ×{' '}
+                                {selectedPageType?.rows})
+                            </div>
+                        )}
+                        <InputError message={errors.page_type_id} className="mt-2" />
+                    </div>
+                </div>
+
+                <div className="space-y-4">
+                    <div>
+                        <InputLabel htmlFor="images" value="Worksheet images" />
+                        <input
+                            id="images"
+                            type="file"
+                            accept="image/*"
+                            multiple
+                            className="mt-1 block w-full text-sm text-slate-600"
+                            onChange={(event) =>
+                                setData(
+                                    'images',
+                                    event.target.files
+                                        ? Array.from(event.target.files)
+                                        : [],
+                                )
+                            }
+                        />
+                        <InputError message={errors.images} className="mt-2" />
+                        <p className="mt-2 text-sm text-slate-500">
+                            {expectedImages > 0
+                                ? `Upload exactly ${expectedImages} image${expectedImages === 1 ? '' : 's'} for this layout.`
+                                : 'Select a layout to see how many images are required.'}
+                        </p>
+                        {mode === 'edit' && (
+                            <p className="text-xs text-slate-400">
+                                Leave this field blank to keep the existing images.
+                            </p>
+                        )}
+                    </div>
+
+                    {selectedPageType && (
+                        <div className="rounded-md border border-dashed border-indigo-300 bg-indigo-50 p-4 text-sm text-indigo-700">
+                            <p className="font-semibold">Layout overview</p>
+                            <p className="mt-1">
+                                {selectedPageType.columns} columns × {selectedPageType.rows} rows
+                                ({selectedPageType.sections} sections total).
+                            </p>
+                            {selectedPageType.logo_url && (
+                                <div className="mt-3">
+                                    <p className="text-xs uppercase tracking-wide text-indigo-500">
+                                        Logo preview
+                                    </p>
+                                    <img
+                                        src={selectedPageType.logo_url}
+                                        alt="Layout logo"
+                                        className="mt-2 h-16 w-16 rounded border border-indigo-200 object-contain"
+                                    />
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {worksheet?.images?.length > 0 && (
+                <div>
+                    <p className="text-sm font-medium text-slate-700">
+                        Current images
+                    </p>
+                    <div
+                        className="mt-3 grid gap-3"
+                        style={{
+                            gridTemplateColumns: `repeat(${selectedPageType?.columns ?? 2}, minmax(0, 1fr))`,
+                        }}
+                    >
+                        {worksheet.images.map((image) => (
+                            <div
+                                key={image.id}
+                                className="overflow-hidden rounded-md border border-slate-200 bg-white"
+                            >
+                                <img
+                                    src={image.image_url}
+                                    alt={`Section ${image.section_index + 1}`}
+                                    className="h-32 w-full object-cover"
+                                />
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            <div className="flex justify-end">
+                <PrimaryButton disabled={processing}>{submitLabel}</PrimaryButton>
+            </div>
+        </form>
+    );
+}

--- a/resources/js/Layouts/AdminLayout.jsx
+++ b/resources/js/Layouts/AdminLayout.jsx
@@ -1,0 +1,164 @@
+import ApplicationLogo from '@/Components/ApplicationLogo';
+import NavLink from '@/Components/NavLink';
+import ResponsiveNavLink from '@/Components/ResponsiveNavLink';
+import { Link, usePage } from '@inertiajs/react';
+import { useState } from 'react';
+
+export default function AdminLayout({ header, children }) {
+    const { props } = usePage();
+    const admin = props.auth?.admin;
+    const status = props.status ?? props.flash?.status ?? null;
+    const [showingNavigationDropdown, setShowingNavigationDropdown] =
+        useState(false);
+
+    return (
+        <div className="min-h-screen bg-slate-100">
+            <nav className="border-b border-slate-200 bg-white">
+                <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+                    <div className="flex h-16 justify-between">
+                        <div className="flex items-center gap-6">
+                            <Link href={route('admin.dashboard')} className="flex items-center gap-2">
+                                <ApplicationLogo className="block h-9 w-auto fill-current text-indigo-600" />
+                                <span className="font-semibold text-slate-800">
+                                    Minha Learnings Admin
+                                </span>
+                            </Link>
+
+                            <div className="hidden space-x-8 sm:flex">
+                                <NavLink
+                                    href={route('admin.dashboard')}
+                                    active={route().current('admin.dashboard')}
+                                >
+                                    Dashboard
+                                </NavLink>
+                                <NavLink
+                                    href={route('admin.page-types.index')}
+                                    active={route().current('admin.page-types.*')}
+                                >
+                                    Page Types
+                                </NavLink>
+                                <NavLink
+                                    href={route('admin.worksheets.index')}
+                                    active={route().current('admin.worksheets.*')}
+                                >
+                                    Worksheets
+                                </NavLink>
+                            </div>
+                        </div>
+
+                        <div className="hidden sm:flex sm:items-center">
+                            {admin && (
+                                <div className="flex items-center gap-4">
+                                    <div className="text-right">
+                                        <p className="text-sm font-medium text-slate-700">
+                                            {admin.name}
+                                        </p>
+                                        <p className="text-xs text-slate-500">{admin.email}</p>
+                                    </div>
+                                    <Link
+                                        href={route('admin.logout')}
+                                        method="post"
+                                        as="button"
+                                        className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow transition hover:bg-indigo-700"
+                                    >
+                                        Log out
+                                    </Link>
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="flex items-center sm:hidden">
+                            <button
+                                onClick={() =>
+                                    setShowingNavigationDropdown(
+                                        (previous) => !previous,
+                                    )
+                                }
+                                className="inline-flex items-center justify-center rounded-md p-2 text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 focus:bg-slate-100 focus:text-slate-700 focus:outline-none"
+                            >
+                                <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d={
+                                            showingNavigationDropdown
+                                                ? 'M6 18L18 6M6 6l12 12'
+                                                : 'M4 6h16M4 12h16M4 18h16'
+                                        }
+                                    />
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <div
+                    className={
+                        (showingNavigationDropdown ? 'block' : 'hidden') +
+                        ' sm:hidden'
+                    }
+                >
+                    <div className="space-y-1 pb-3 pt-2">
+                        <ResponsiveNavLink
+                            href={route('admin.dashboard')}
+                            active={route().current('admin.dashboard')}
+                        >
+                            Dashboard
+                        </ResponsiveNavLink>
+                        <ResponsiveNavLink
+                            href={route('admin.page-types.index')}
+                            active={route().current('admin.page-types.*')}
+                        >
+                            Page Types
+                        </ResponsiveNavLink>
+                        <ResponsiveNavLink
+                            href={route('admin.worksheets.index')}
+                            active={route().current('admin.worksheets.*')}
+                        >
+                            Worksheets
+                        </ResponsiveNavLink>
+                    </div>
+
+                    <div className="border-t border-slate-200 pb-1 pt-4">
+                        {admin && (
+                            <div className="px-4">
+                                <p className="text-base font-medium text-slate-800">
+                                    {admin.name}
+                                </p>
+                                <p className="text-sm text-slate-500">{admin.email}</p>
+
+                                <ResponsiveNavLink
+                                    method="post"
+                                    href={route('admin.logout')}
+                                    as="button"
+                                    className="mt-3"
+                                >
+                                    Log out
+                                </ResponsiveNavLink>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </nav>
+
+            {status && (
+                <div className="bg-emerald-50 py-3 text-center text-sm font-medium text-emerald-700">
+                    {status}
+                </div>
+            )}
+
+            {header && (
+                <header className="bg-white shadow">
+                    <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+                        {header}
+                    </div>
+                </header>
+            )}
+
+            <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+                {children}
+            </main>
+        </div>
+    );
+}

--- a/resources/js/Pages/Admin/Auth/Login.jsx
+++ b/resources/js/Pages/Admin/Auth/Login.jsx
@@ -1,0 +1,93 @@
+import Checkbox from '@/Components/Checkbox';
+import InputError from '@/Components/InputError';
+import InputLabel from '@/Components/InputLabel';
+import PrimaryButton from '@/Components/PrimaryButton';
+import TextInput from '@/Components/TextInput';
+import GuestLayout from '@/Layouts/GuestLayout';
+import { Head, useForm } from '@inertiajs/react';
+
+export default function Login({ status }) {
+    const { data, setData, post, processing, errors, reset } = useForm({
+        email: '',
+        password: '',
+        remember: false,
+    });
+
+    const submit = (event) => {
+        event.preventDefault();
+
+        post(route('admin.login.store'), {
+            onFinish: () => reset('password'),
+        });
+    };
+
+    return (
+        <GuestLayout>
+            <Head title="Admin Login" />
+
+            <h1 className="mb-6 text-center text-2xl font-bold text-slate-800">
+                Admin Access
+            </h1>
+
+            {status && (
+                <div className="mb-4 rounded-md bg-emerald-50 p-3 text-sm font-medium text-emerald-700">
+                    {status}
+                </div>
+            )}
+
+            <form onSubmit={submit}>
+                <div>
+                    <InputLabel htmlFor="email" value="Email" />
+
+                    <TextInput
+                        id="email"
+                        type="email"
+                        name="email"
+                        value={data.email}
+                        className="mt-1 block w-full"
+                        autoComplete="username"
+                        isFocused
+                        onChange={(e) => setData('email', e.target.value)}
+                    />
+
+                    <InputError message={errors.email} className="mt-2" />
+                </div>
+
+                <div className="mt-4">
+                    <InputLabel htmlFor="password" value="Password" />
+
+                    <TextInput
+                        id="password"
+                        type="password"
+                        name="password"
+                        value={data.password}
+                        className="mt-1 block w-full"
+                        autoComplete="current-password"
+                        onChange={(e) => setData('password', e.target.value)}
+                    />
+
+                    <InputError message={errors.password} className="mt-2" />
+                </div>
+
+                <div className="mt-4 flex items-center justify-between">
+                    <label className="flex items-center text-sm text-slate-600">
+                        <Checkbox
+                            name="remember"
+                            checked={data.remember}
+                            onChange={(event) =>
+                                setData('remember', event.target.checked)
+                            }
+                        />
+                        <span className="ms-2">Remember me</span>
+                    </label>
+                </div>
+
+                <div className="mt-6">
+                    <PrimaryButton className="w-full justify-center" disabled={processing}>
+                        Sign in
+                    </PrimaryButton>
+                </div>
+            </form>
+        </GuestLayout>
+    );
+}

--- a/resources/js/Pages/Admin/Dashboard.jsx
+++ b/resources/js/Pages/Admin/Dashboard.jsx
@@ -1,0 +1,37 @@
+import AdminLayout from '@/Layouts/AdminLayout';
+import { Head } from '@inertiajs/react';
+
+export default function Dashboard({ metrics }) {
+    return (
+        <AdminLayout
+            header={
+                <div>
+                    <h2 className="text-3xl font-semibold leading-tight text-slate-800">
+                        Minha Learnings
+                    </h2>
+                    <p className="mt-1 text-sm text-slate-500">
+                        Welcome back to your activity workspace.
+                    </p>
+                </div>
+            }
+        >
+            <Head title="Admin Dashboard" />
+
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                <MetricCard label="Page Types" value={metrics?.page_types ?? 0} />
+                <MetricCard label="Worksheets" value={metrics?.worksheets ?? 0} />
+            </div>
+        </AdminLayout>
+    );
+}
+
+function MetricCard({ label, value }) {
+    return (
+        <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+            <p className="text-sm uppercase tracking-wide text-slate-500">
+                {label}
+            </p>
+            <p className="mt-2 text-3xl font-semibold text-slate-800">{value}</p>
+        </div>
+    );
+}

--- a/resources/js/Pages/Admin/PageTypes/Create.jsx
+++ b/resources/js/Pages/Admin/PageTypes/Create.jsx
@@ -1,0 +1,42 @@
+import PageTypeForm from '@/Components/Admin/PageTypeForm';
+import AdminLayout from '@/Layouts/AdminLayout';
+import { Head, useForm } from '@inertiajs/react';
+
+export default function Create() {
+    const form = useForm({
+        name: '',
+        columns: 2,
+        rows: 4,
+        logo: null,
+    });
+
+    const submit = (event) => {
+        event.preventDefault();
+        form.post(route('admin.page-types.store'), {
+            forceFormData: true,
+            onSuccess: () => form.setData('logo', null),
+        });
+    };
+
+    return (
+        <AdminLayout
+            header={
+                <h2 className="text-2xl font-semibold leading-tight text-slate-800">
+                    Create page type
+                </h2>
+            }
+        >
+            <Head title="Create Page Type" />
+
+            <PageTypeForm
+                data={form.data}
+                setData={form.setData}
+                errors={form.errors}
+                processing={form.processing}
+                onSubmit={submit}
+                pageType={null}
+                submitLabel="Create"
+            />
+        </AdminLayout>
+    );
+}

--- a/resources/js/Pages/Admin/PageTypes/Edit.jsx
+++ b/resources/js/Pages/Admin/PageTypes/Edit.jsx
@@ -1,0 +1,43 @@
+import PageTypeForm from '@/Components/Admin/PageTypeForm';
+import AdminLayout from '@/Layouts/AdminLayout';
+import { Head, useForm } from '@inertiajs/react';
+
+export default function Edit({ pageType }) {
+    const form = useForm({
+        name: pageType.name || '',
+        columns: pageType.columns || 1,
+        rows: pageType.rows || 1,
+        logo: null,
+    });
+
+    const submit = (event) => {
+        event.preventDefault();
+        form.put(route('admin.page-types.update', pageType.id), {
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => form.setData('logo', null),
+        });
+    };
+
+    return (
+        <AdminLayout
+            header={
+                <h2 className="text-2xl font-semibold leading-tight text-slate-800">
+                    Edit {pageType.name}
+                </h2>
+            }
+        >
+            <Head title={`Edit ${pageType.name}`} />
+
+            <PageTypeForm
+                data={form.data}
+                setData={form.setData}
+                errors={form.errors}
+                processing={form.processing}
+                onSubmit={submit}
+                pageType={pageType}
+                submitLabel="Update"
+            />
+        </AdminLayout>
+    );
+}

--- a/resources/js/Pages/Admin/PageTypes/Index.jsx
+++ b/resources/js/Pages/Admin/PageTypes/Index.jsx
@@ -1,0 +1,142 @@
+import DangerButton from '@/Components/DangerButton';
+import AdminLayout from '@/Layouts/AdminLayout';
+import { Head, Link, router } from '@inertiajs/react';
+
+export default function Index({ pageTypes }) {
+    const handleDelete = (id) => {
+        if (
+            !window.confirm(
+                'Deleting this page type will remove all related worksheets. Continue?',
+            )
+        ) {
+            return;
+        }
+
+        router.delete(route('admin.page-types.destroy', id));
+    };
+
+    return (
+        <AdminLayout
+            header={
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h2 className="text-2xl font-semibold leading-tight text-slate-800">
+                            Page Types
+                        </h2>
+                        <p className="text-sm text-slate-500">
+                            Define printable layouts that can be reused across worksheets.
+                        </p>
+                    </div>
+                    <Link
+                        href={route('admin.page-types.create')}
+                        className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-indigo-700"
+                    >
+                        Create page type
+                    </Link>
+                </div>
+            }
+        >
+            <Head title="Page Types" />
+
+            <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+                <table className="min-w-full divide-y divide-slate-200">
+                    <thead className="bg-slate-50">
+                        <tr>
+                            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
+                                Name
+                            </th>
+                            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
+                                Layout
+                            </th>
+                            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
+                                Sections
+                            </th>
+                            <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wide text-slate-500">
+                                Actions
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-200">
+                        {pageTypes.data.length === 0 && (
+                            <tr>
+                                <td
+                                    colSpan={4}
+                                    className="px-6 py-8 text-center text-sm text-slate-500"
+                                >
+                                    No page types created yet.
+                                </td>
+                            </tr>
+                        )}
+
+                        {pageTypes.data.map((pageType) => (
+                            <tr key={pageType.id}>
+                                <td className="px-6 py-4 text-sm font-medium text-slate-800">
+                                    <div className="flex items-center gap-3">
+                                        {pageType.logo_url && (
+                                            <img
+                                                src={pageType.logo_url}
+                                                alt="Logo"
+                                                className="h-10 w-10 rounded border border-slate-200 object-contain"
+                                            />
+                                        )}
+                                        <span>{pageType.name}</span>
+                                    </div>
+                                </td>
+                                <td className="px-6 py-4 text-sm text-slate-600">
+                                    {pageType.columns} × {pageType.rows}
+                                </td>
+                                <td className="px-6 py-4 text-sm text-slate-600">
+                                    {pageType.sections}
+                                </td>
+                                <td className="px-6 py-4">
+                                    <div className="flex justify-end gap-2">
+                                        <Link
+                                            href={route('admin.page-types.edit', pageType.id)}
+                                            className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+                                        >
+                                            Edit
+                                        </Link>
+                                        <DangerButton
+                                            onClick={() => handleDelete(pageType.id)}
+                                            className="text-sm"
+                                        >
+                                            Delete
+                                        </DangerButton>
+                                    </div>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+
+            {(pageTypes.links.prev || pageTypes.links.next) && (
+                <div className="mt-4 flex items-center justify-between">
+                    <button
+                        type="button"
+                        disabled={!pageTypes.links.prev}
+                        onClick={() =>
+                            pageTypes.links.prev && router.visit(pageTypes.links.prev)
+                        }
+                        className="rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        Previous
+                    </button>
+                    <span className="text-sm text-slate-500">
+                        Page {pageTypes.meta.current_page} of {pageTypes.meta.last_page}
+                    </span>
+                    <button
+                        type="button"
+                        disabled={!pageTypes.links.next}
+                        onClick={() =>
+                            pageTypes.links.next && router.visit(pageTypes.links.next)
+                        }
+                        className="rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        Next
+                    </button>
+                </div>
+            )}
+        </AdminLayout>
+    );
+}

--- a/resources/js/Pages/Admin/Worksheets/Create.jsx
+++ b/resources/js/Pages/Admin/Worksheets/Create.jsx
@@ -1,0 +1,46 @@
+import WorksheetForm from '@/Components/Admin/WorksheetForm';
+import AdminLayout from '@/Layouts/AdminLayout';
+import { Head, useForm } from '@inertiajs/react';
+
+export default function Create({ pageTypes }) {
+    const form = useForm({
+        title: '',
+        notes: '',
+        page_type_id: '',
+        images: [],
+    });
+
+    const submit = (event) => {
+        event.preventDefault();
+        form.post(route('admin.worksheets.store'), {
+            forceFormData: true,
+            onSuccess: () => {
+                form.reset('title', 'notes', 'page_type_id');
+                form.setData('images', []);
+            },
+        });
+    };
+
+    return (
+        <AdminLayout
+            header={
+                <h2 className="text-2xl font-semibold leading-tight text-slate-800">
+                    Create worksheet
+                </h2>
+            }
+        >
+            <Head title="Create Worksheet" />
+
+            <WorksheetForm
+                data={form.data}
+                setData={form.setData}
+                errors={form.errors}
+                processing={form.processing}
+                onSubmit={submit}
+                pageTypes={pageTypes}
+                submitLabel="Create"
+                mode="create"
+            />
+        </AdminLayout>
+    );
+}

--- a/resources/js/Pages/Admin/Worksheets/Edit.jsx
+++ b/resources/js/Pages/Admin/Worksheets/Edit.jsx
@@ -1,0 +1,44 @@
+import WorksheetForm from '@/Components/Admin/WorksheetForm';
+import AdminLayout from '@/Layouts/AdminLayout';
+import { Head, useForm } from '@inertiajs/react';
+
+export default function Edit({ worksheet }) {
+    const form = useForm({
+        title: worksheet.title || '',
+        notes: worksheet.notes || '',
+        page_type_id: worksheet.page_type_id,
+        images: [],
+    });
+
+    const submit = (event) => {
+        event.preventDefault();
+        form.put(route('admin.worksheets.update', worksheet.id), {
+            forceFormData: true,
+            preserveScroll: true,
+            onSuccess: () => form.setData('images', []),
+        });
+    };
+
+    return (
+        <AdminLayout
+            header={
+                <h2 className="text-2xl font-semibold leading-tight text-slate-800">
+                    Edit {worksheet.title}
+                </h2>
+            }
+        >
+            <Head title={`Edit ${worksheet.title}`} />
+
+            <WorksheetForm
+                data={form.data}
+                setData={form.setData}
+                errors={form.errors}
+                processing={form.processing}
+                onSubmit={submit}
+                worksheet={worksheet}
+                submitLabel="Update"
+                mode="edit"
+            />
+        </AdminLayout>
+    );
+}

--- a/resources/js/Pages/Admin/Worksheets/Index.jsx
+++ b/resources/js/Pages/Admin/Worksheets/Index.jsx
@@ -1,0 +1,135 @@
+import DangerButton from '@/Components/DangerButton';
+import AdminLayout from '@/Layouts/AdminLayout';
+import { Head, Link, router } from '@inertiajs/react';
+
+export default function Index({ worksheets }) {
+    const handleDelete = (id) => {
+        if (!window.confirm('Are you sure you want to delete this worksheet?')) {
+            return;
+        }
+
+        router.delete(route('admin.worksheets.destroy', id));
+    };
+
+    return (
+        <AdminLayout
+            header={
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h2 className="text-2xl font-semibold leading-tight text-slate-800">
+                            Worksheets
+                        </h2>
+                        <p className="text-sm text-slate-500">
+                            Upload activity sheets that match your selected page type layouts.
+                        </p>
+                    </div>
+                    <Link
+                        href={route('admin.worksheets.create')}
+                        className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-indigo-700"
+                    >
+                        Create worksheet
+                    </Link>
+                </div>
+            }
+        >
+            <Head title="Worksheets" />
+
+            <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+                <table className="min-w-full divide-y divide-slate-200">
+                    <thead className="bg-slate-50">
+                        <tr>
+                            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
+                                Title
+                            </th>
+                            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
+                                Layout
+                            </th>
+                            <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wide text-slate-500">
+                                Uploaded
+                            </th>
+                            <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wide text-slate-500">
+                                Actions
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-200">
+                        {worksheets.data.length === 0 && (
+                            <tr>
+                                <td
+                                    colSpan={4}
+                                    className="px-6 py-8 text-center text-sm text-slate-500"
+                                >
+                                    No worksheets have been created yet.
+                                </td>
+                            </tr>
+                        )}
+
+                        {worksheets.data.map((worksheet) => (
+                            <tr key={worksheet.id}>
+                                <td className="px-6 py-4 text-sm font-medium text-slate-800">
+                                    {worksheet.title}
+                                </td>
+                                <td className="px-6 py-4 text-sm text-slate-600">
+                                    {worksheet.page_type?.name} ({worksheet.page_type?.sections} sections)
+                                </td>
+                                <td className="px-6 py-4 text-sm text-slate-600">
+                                    {new Date(worksheet.created_at).toLocaleDateString()}
+                                </td>
+                                <td className="px-6 py-4">
+                                    <div className="flex justify-end gap-3 text-sm font-medium">
+                                        <Link
+                                            href={route('admin.worksheets.show', worksheet.id)}
+                                            className="text-indigo-600 hover:text-indigo-800"
+                                        >
+                                            Preview
+                                        </Link>
+                                        <Link
+                                            href={route('admin.worksheets.edit', worksheet.id)}
+                                            className="text-slate-600 hover:text-slate-800"
+                                        >
+                                            Edit
+                                        </Link>
+                                        <DangerButton
+                                            onClick={() => handleDelete(worksheet.id)}
+                                            className="text-sm"
+                                        >
+                                            Delete
+                                        </DangerButton>
+                                    </div>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+
+            {(worksheets.links.prev || worksheets.links.next) && (
+                <div className="mt-4 flex items-center justify-between">
+                    <button
+                        type="button"
+                        disabled={!worksheets.links.prev}
+                        onClick={() =>
+                            worksheets.links.prev && router.visit(worksheets.links.prev)
+                        }
+                        className="rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        Previous
+                    </button>
+                    <span className="text-sm text-slate-500">
+                        Page {worksheets.meta.current_page} of {worksheets.meta.last_page}
+                    </span>
+                    <button
+                        type="button"
+                        disabled={!worksheets.links.next}
+                        onClick={() =>
+                            worksheets.links.next && router.visit(worksheets.links.next)
+                        }
+                        className="rounded-md border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        Next
+                    </button>
+                </div>
+            )}
+        </AdminLayout>
+    );
+}

--- a/resources/js/Pages/Admin/Worksheets/Show.jsx
+++ b/resources/js/Pages/Admin/Worksheets/Show.jsx
@@ -1,0 +1,87 @@
+import AdminLayout from '@/Layouts/AdminLayout';
+import { Head, Link } from '@inertiajs/react';
+
+export default function Show({ worksheet }) {
+    const columns = worksheet.page_type?.columns ?? 1;
+    const rows = worksheet.page_type?.rows ?? 1;
+
+    const handlePrint = () => {
+        window.print();
+    };
+
+    return (
+        <AdminLayout
+            header={
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h2 className="text-2xl font-semibold leading-tight text-slate-800">
+                            {worksheet.title}
+                        </h2>
+                        <p className="text-sm text-slate-500">
+                            {worksheet.page_type?.name} layout — {worksheet.page_type?.sections} sections
+                        </p>
+                    </div>
+                    <div className="flex items-center gap-3">
+                        <Link
+                            href={route('admin.worksheets.edit', worksheet.id)}
+                            className="inline-flex items-center rounded-md border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100"
+                        >
+                            Edit worksheet
+                        </Link>
+                        <button
+                            type="button"
+                            onClick={handlePrint}
+                            className="inline-flex items-center rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-indigo-700 print:hidden"
+                        >
+                            Print
+                        </button>
+                    </div>
+                </div>
+            }
+        >
+            <Head title={`${worksheet.title} Preview`} />
+
+            <div className="flex justify-center">
+                <div className="a4-sheet">
+                    <header className="mb-6 flex items-start justify-between gap-4">
+                        {worksheet.page_type?.logo_url ? (
+                            <img
+                                src={worksheet.page_type.logo_url}
+                                alt="Worksheet logo"
+                                className="h-16 w-16 object-contain"
+                            />
+                        ) : (
+                            <div className="h-16 w-16" aria-hidden="true" />
+                        )}
+                        <div className="flex-1 text-center">
+                            <h1 className="text-3xl font-semibold text-slate-800">
+                                {worksheet.title}
+                            </h1>
+                            {worksheet.notes && (
+                                <p className="mt-2 text-sm text-slate-500">{worksheet.notes}</p>
+                            )}
+                        </div>
+                    </header>
+
+                    <div
+                        className="a4-grid"
+                        style={{
+                            gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+                            gridTemplateRows: `repeat(${rows}, minmax(0, 1fr))`,
+                        }}
+                    >
+                        {worksheet.images.map((image) => (
+                            <div key={image.id} className="a4-grid__cell">
+                                <img
+                                    src={image.image_url}
+                                    alt={`Worksheet item ${image.section_index + 1}`}
+                                    className="h-full w-full object-contain"
+                                />
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </AdminLayout>
+    );
+}

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Admin\Auth\AuthenticatedSessionController;
+use App\Http\Controllers\Admin\DashboardController;
+use App\Http\Controllers\Admin\PageTypeController;
+use App\Http\Controllers\Admin\WorksheetController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('guest:admin')->group(function (): void {
+    Route::get('login', [AuthenticatedSessionController::class, 'create'])
+        ->name('login');
+    Route::post('login', [AuthenticatedSessionController::class, 'store'])
+        ->name('login.store');
+});
+
+Route::middleware('auth:admin')->group(function (): void {
+    Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
+        ->name('logout');
+
+    Route::get('/', [DashboardController::class, 'index'])
+        ->name('dashboard');
+
+    Route::resource('page-types', PageTypeController::class)->except('show');
+    Route::resource('worksheets', WorksheetController::class);
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,10 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+    }
 }


### PR DESCRIPTION
## Summary
- add an `admin` guard, routes, and login controller along with a seeded administrator account
- implement page type and worksheet domain models, migrations, requests, resources, and services for CRUD workflows and image storage
- build Inertia admin pages/layouts for managing page types and worksheets with printable previews, plus adjust test bootstrap to skip Vite assets

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68c9930b82c88327a5a8a6cc2a956919